### PR TITLE
Integrate endpoint into example

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
     branches:
       - master
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
-/target
-/Cargo.lock
+Cargo.lock
+debug/
+target/
+
+**/*.rs.bk
+
+.idea
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,8 @@ tokio-util = "0.7"
 tower-service = "0.3.2"
 
 [dev-dependencies]
-h3-quinn = { git = "https://github.com/hyperium/h3" }
+quinn = { version = "0.8", default-features = false, features = ["tls-rustls", "ring"] }
 rustls = "0.20"
 rustls-native-certs = "0.6"
 tokio = { version = "1.19.2", features = ["full"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi", "env-filter", "time"] }
-quinn = { version = "0.8", default-features = false, features = ["tls-rustls", "ring"] }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,22 +1,30 @@
+use std::error::Error;
+use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
-use futures::future;
-use h3_quinn::quinn;
+use futures::future::{self, Future};
 use http_body::Body;
 use tokio::io::AsyncWriteExt;
+use tower_h3::client::Endpoint;
 use tower_service::Service;
 
 static ALPN: &[u8] = b"h3";
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .with_span_events(tracing_subscriber::fmt::format::FmtSpan::FULL)
         .with_writer(std::io::stderr)
         .init();
 
-    let dest = std::env::args().nth(1).expect("uri required via CLI").parse::<http::Uri>().unwrap();
+    let dest = std::env::args()
+        .nth(1)
+        .expect("uri required via CLI")
+        .parse::<http::Uri>()
+        .unwrap();
 
     if dest.scheme() != Some(&http::uri::Scheme::HTTPS) {
         Err("destination scheme must be 'https'")?;
@@ -42,6 +50,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_safe_default_cipher_suites()
         .with_safe_default_kx_groups()
         .with_protocol_versions(&[&rustls::version::TLS13])?;
+
     let mut roots = rustls::RootCertStore::empty();
     match rustls_native_certs::load_native_certs() {
         Ok(certs) => {
@@ -55,21 +64,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             eprintln!("couldn't load any default trust roots: {}", e);
         }
     };
+
     let mut tls_config = tls_config_builder
         .with_root_certificates(roots)
         .with_no_client_auth();
     tls_config.enable_early_data = true;
     tls_config.alpn_protocols = vec![ALPN.into()];
-    let client_config = quinn::ClientConfig::new(Arc::new(tls_config));
 
-    let mut client_endpoint = h3_quinn::quinn::Endpoint::client("[::]:0".parse().unwrap())?;
-    client_endpoint.set_default_client_config(client_config);
-    let quinn_conn = h3_quinn::Connection::new(client_endpoint.connect(addr, auth.host())?.await?);
+    let client_config = quinn::ClientConfig::new(Arc::new(tls_config));
+    let mut quinn_endpoint = quinn::Endpoint::client("[::]:0".parse().unwrap())?;
+    quinn_endpoint.set_default_client_config(client_config);
+
+    let conn = Connect::new(quinn_endpoint.clone());
+
+    // TODO make type inference work and remove this
+    let mut endpoint: Endpoint<Connect, http_body::Empty<bytes::Bytes>> = Endpoint::new(conn);
+    let (mut driver, mut service) = endpoint.call((addr, auth.host())).await?;
 
     eprintln!("QUIC connected ...");
-
-    // generic h3
-    let (mut driver, mut send_request) = h3::client::new(quinn_conn).await?;
 
     tokio::spawn(async move {
         if let Err(e) = future::poll_fn(|cx| driver.poll_close(cx)).await {
@@ -77,14 +89,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     });
 
-    let mut svc = tower_h3::client::Connection::new(send_request);
-
     eprintln!("Sending request ...");
     let req = http::Request::builder()
         .uri(dest)
         .body(http_body::Empty::new())?;
 
-    let mut resp = svc.call(req).await?;
+    let mut resp = service.call(req).await?;
 
     eprintln!("Received response ...");
 
@@ -98,8 +108,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         out.flush().await.expect("flush");
     }
 
-    drop(svc);
-    client_endpoint.wait_idle().await;
+    drop(service);
+    quinn_endpoint.wait_idle().await;
 
     Ok(())
+}
+
+pub struct Connect {
+    inner: h3_quinn::quinn::Endpoint,
+}
+
+impl Connect {
+    pub fn new(inner: h3_quinn::quinn::Endpoint) -> Self {
+        Self { inner }
+    }
+}
+
+impl Service<(SocketAddr, &str)> for Connect {
+    type Response = h3_quinn::Connection;
+    type Error = Box<dyn Error>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, dst: (SocketAddr, &str)) -> Self::Future {
+        let (addr, server_name) = dst;
+        let connecting = self.inner.connect(addr, server_name);
+
+        Box::pin(async move {
+            let conn = connecting?.await?;
+            Ok(h3_quinn::Connection::new(conn))
+        })
+    }
 }

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -1,19 +1,24 @@
-use std::future::Future;
 use std::pin::Pin;
-use std::task::{self, Poll};
+use std::task::{Context, Poll};
 
-use bytes::{Bytes, Buf};
+use bytes::{Buf, Bytes};
+use futures::future::Future;
+use h3::client::{RequestStream, SendRequest};
 use h3::quic;
 use http_body::Body;
 use tokio_util::sync::ReusableBoxFuture;
 use tower_service::Service;
 
-pub struct Connection<T: quic::OpenStreams<B::Data>, B: Body> {
-    tx: h3::client::SendRequest<T, B::Data>,
+pub struct Connection<T, B>
+where
+    T: quic::OpenStreams<B::Data>,
+    B: Body,
+{
+    tx: SendRequest<T, B::Data>,
 }
 
 pub struct RecvStream<T: quic::RecvStream, B> {
-    data_fut: ReusableBoxFuture<'static, (Option<Result<Bytes, h3::Error>>, h3::client::RequestStream<T, B>)>,
+    data_fut: ReusableBoxFuture<'static, (Option<Result<Bytes, h3::Error>>, RequestStream<T, B>)>,
 }
 
 impl<T, B> Connection<T, B>
@@ -21,8 +26,7 @@ where
     T: quic::OpenStreams<B::Data>,
     B: Body,
 {
-    // TODO: make private
-    pub fn new(tx: h3::client::SendRequest<T, B::Data>) -> Self {
+    pub(crate) fn new(tx: SendRequest<T, B::Data>) -> Self {
         Self { tx }
     }
 }
@@ -42,21 +46,21 @@ where
     type Error = h3::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
-    fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, req: http::Request<B>) -> Self::Future {
-        let (parts, body) = req.into_parts();
+        let (parts, _body) = req.into_parts();
         let req = http::Request::from_parts(parts, ());
 
         let mut tx = self.tx.clone();
 
         Box::pin(async move {
-            let mut st = tx.send_request(req).await?;
-            let resp = st.recv_response().await?;
+            let mut stream = tx.send_request(req).await?;
+            let resp = stream.recv_response().await?;
             let body = RecvStream {
-                data_fut: ReusableBoxFuture::new(make_data_fut(st)),
+                data_fut: ReusableBoxFuture::new(make_data_fut(stream)),
             };
             Ok(resp.map(move |()| body))
         })
@@ -74,19 +78,26 @@ where
     type Data = bytes::Bytes;
     type Error = h3::Error;
 
-    fn poll_data(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+    fn poll_data(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
         let (result, rx) = futures::ready!(self.data_fut.poll(cx));
         self.data_fut.set(make_data_fut(rx));
         Poll::Ready(result)
     }
 
-    fn poll_trailers(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
         todo!("poll_trailers");
     }
 }
 
-async fn make_data_fut<T, B>(mut rx: h3::client::RequestStream<T, B>)
-    -> (Option<Result<Bytes, h3::Error>>, h3::client::RequestStream<T, B>)
+async fn make_data_fut<T, B>(
+    mut rx: RequestStream<T, B>,
+) -> (Option<Result<Bytes, h3::Error>>, RequestStream<T, B>)
 where
     T: quic::RecvStream,
 {

--- a/src/client/endpoint.rs
+++ b/src/client/endpoint.rs
@@ -1,7 +1,10 @@
 use std::marker::PhantomData;
 use std::pin::Pin;
-use std::task::{self, Poll};
+use std::task::{Context, Poll};
 
+use futures::future::Future;
+use h3::quic;
+use http_body::Body;
 use tower_service::Service;
 
 pub struct Endpoint<C, B> {
@@ -9,35 +12,46 @@ pub struct Endpoint<C, B> {
     _body: PhantomData<fn() -> fn(B)>,
 }
 
-impl<C, Dst, O, B> Service<Dst> for Endpoint<C, B>
+impl<C, B> Endpoint<C, B> {
+    pub fn new(inner: C) -> Self {
+        Self {
+            inner,
+            _body: PhantomData,
+        }
+    }
+}
+
+impl<C, D, O, B> Service<D> for Endpoint<C, B>
 where
-    C: Service<Dst>,
-    C::Response: h3::quic::Connection<B::Data, OpenStreams = O> + Send + 'static,
+    C: Service<D>,
+    C::Response: quic::Connection<B::Data, OpenStreams = O> + Send + 'static,
     C::Future: Send + 'static,
-    O: h3::quic::OpenStreams<B::Data> + Send + 'static,
-    <C::Response as h3::quic::Connection<B::Data>>::SendStream: Send + 'static,
-    B: http_body::Body + Send + 'static,
+    O: quic::OpenStreams<B::Data> + Send + 'static,
+    <C::Response as quic::Connection<B::Data>>::SendStream: Send + 'static,
+    <C::Response as quic::Connection<B::Data>>::RecvStream: Send + 'static,
+    B: Body + Send + 'static,
     B::Data: Send + 'static,
 {
-    type Response = super::Connection<O, B>;
+    type Response = (
+        h3::client::Connection<C::Response, B::Data>,
+        super::Connection<O, B>,
+    );
     type Error = h3::Error;
-    type Future = Pin<Box<dyn std::future::Future<Output=Result<Self::Response, Self::Error>> + Send>>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
-
-    fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, dst: Dst) -> Self::Future {
+    fn call(&mut self, dst: D) -> Self::Future {
         let connecting = self.inner.call(dst);
 
         Box::pin(async move {
-            let conn = connecting.await.unwrap_or_else(|_| panic!("connecting error"));
-
-            let (driver, tx) = h3::client::builder()
-                .build(conn)
-                .await?;
-            Ok(super::Connection::new(tx))
+            let conn = connecting
+                .await
+                .unwrap_or_else(|_| panic!("connecting error"));
+            let (driver, send_request) = h3::client::builder().build(conn).await?;
+            Ok((driver, super::Connection::new(send_request)))
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,3 @@
+#![allow(clippy::type_complexity)]
+
 pub mod client;


### PR DESCRIPTION
Tuned clippy a bit to ignore type_complexity. It seemed like an overkill even for warnings.